### PR TITLE
Display Robomimic simulations side-by-side

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,29 +375,29 @@
   <div class="hero-body">
     <div class="container">
       <h2 class="title is-3">Evaluations on Robomimic Simulation Benchmark</h2>
-      <div class="columns is-centered">
-        
-        <div class="column is-one-third has-text-centered">
-          <video poster="" id="video1" controls muted loop preload="metadata" style="width:200px; height:auto;">
+      <div class="robomimic-video-row">
+
+        <div class="robomimic-video-card has-text-centered">
+          <video poster="" id="video1" controls muted loop preload="metadata">
             <source src="static/videos/can.mp4" type="video/mp4">
           </video>
           <p class="mt-3">The Can task involves picking up a can and placing it in the correct bin, testing pick-and-place skills.</p>
         </div>
-        
-        <div class="column is-one-third has-text-centered">
-          <video poster="" id="video2" controls muted loop preload="metadata" style="width:200px; height:auto;">
+
+        <div class="robomimic-video-card has-text-centered">
+          <video poster="" id="video2" controls muted loop preload="metadata">
             <source src="static/videos/lift.mp4" type="video/mp4">
           </video>
           <p class="mt-3">The Lift task involves lifting an object, a simple manipulation task that benefits less from large datasets compared to complex tasks.</p>
         </div>
-        
-        <div class="column is-one-third has-text-centered">
-          <video poster="" id="video3" controls muted loop preload="metadata" style="width:200px; height:auto;">
+
+        <div class="robomimic-video-card has-text-centered">
+          <video poster="" id="video3" controls muted loop preload="metadata">
             <source src="static/videos/square.mp4" type="video/mp4">
           </video>
           <p class="mt-3">The Square task, also known as Square Nut Assembly, requires fitting a square nut onto a square peg.</p>
         </div>
-        
+
       </div>
     </div>
   </div>

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -290,6 +290,41 @@ body {
   font-weight: 500;
 }
 
+.robomimic-video-row {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 1.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.robomimic-video-row::-webkit-scrollbar {
+  height: 6px;
+}
+
+.robomimic-video-row::-webkit-scrollbar-thumb {
+  background-color: rgba(37, 99, 235, 0.4);
+  border-radius: 999px;
+}
+
+.robomimic-video-card {
+  flex: 0 0 180px;
+  max-width: 180px;
+}
+
+.robomimic-video-card video {
+  width: 100%;
+  height: auto;
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-sm);
+}
+
+.robomimic-video-card p {
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
 /* Pagination and Misc Improvements */
 .slider-pagination .slider-page {
   background: var(--primary-color);


### PR DESCRIPTION
## Summary
- show all Robomimic benchmark videos simultaneously in a new horizontal layout
- add styling that constrains each video card size and supports horizontal scrolling on smaller screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db2aa70280832e944a649a632028bc