### PR TITLE
Update UR5 video grid layout

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -335,9 +335,21 @@ body {
   border-radius: 999px;
 }
 
+.real-world-video-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+
+@media (min-width: 768px) {
+  .real-world-video-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 .real-world-video-card {
-  flex: 0 0 350px;
-  max-width: 350px;
+  width: 100%;
+  max-width: none;
 }
 
 .real-world-video-card video {


### PR DESCRIPTION
## Summary
- switch the UR5 video gallery to a responsive two-column grid
- allow each video card to span the full column width for a larger presentation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db566cc388832eb1d3f4808646c9d4